### PR TITLE
fix: improve HTML/XML tag readability (#10)

### DIFF
--- a/extras/helix/monoglow_lack.toml
+++ b/extras/helix/monoglow_lack.toml
@@ -57,7 +57,7 @@ special = { fg = "#f1f1f1" }
 string = { fg = "#aaaaaa" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
-tag = { fg = "#555555" }
+tag = { fg = "#aaaaaa" }
 type = { fg = "#aaaaaa" }
 "type.builtin" = { fg = "#aaaaaa" }
 "type.enum" = { fg = "#aaaaaa" }
@@ -165,7 +165,7 @@ selection = "#1f1f1f"
 "syntax.special" = "#f1f1f1"
 "syntax.string" = "#aaaaaa"
 "syntax.string_escape" = "#708090"
-"syntax.tag" = "#555555"
+"syntax.tag" = "#aaaaaa"
 "syntax.type" = "#aaaaaa"
 "syntax.type_def" = "#cccccc"
 "syntax.type_primitive" = "#aaaaaa"

--- a/extras/helix/monoglow_void.toml
+++ b/extras/helix/monoglow_void.toml
@@ -57,7 +57,7 @@ special = { fg = "#f1f1f1" }
 string = { fg = "#b1b1b1" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
-tag = { fg = "#585858" }
+tag = { fg = "#b1b1b1" }
 type = { fg = "#b1b1b1" }
 "type.builtin" = { fg = "#b1b1b1" }
 "type.enum" = { fg = "#b1b1b1" }
@@ -165,7 +165,7 @@ selection = "#292929"
 "syntax.special" = "#f1f1f1"
 "syntax.string" = "#b1b1b1"
 "syntax.string_escape" = "#708090"
-"syntax.tag" = "#585858"
+"syntax.tag" = "#b1b1b1"
 "syntax.type" = "#b1b1b1"
 "syntax.type_def" = "#d1d1d1"
 "syntax.type_primitive" = "#b1b1b1"

--- a/extras/helix/monoglow_z.toml
+++ b/extras/helix/monoglow_z.toml
@@ -57,7 +57,7 @@ special = { fg = "#f1f1f1" }
 string = { fg = "#aaaaaa" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
-tag = { fg = "#555555" }
+tag = { fg = "#aaaaaa" }
 type = { fg = "#aaaaaa" }
 "type.builtin" = { fg = "#aaaaaa" }
 "type.enum" = { fg = "#aaaaaa" }
@@ -165,7 +165,7 @@ selection = "#212121"
 "syntax.special" = "#f1f1f1"
 "syntax.string" = "#aaaaaa"
 "syntax.string_escape" = "#708090"
-"syntax.tag" = "#555555"
+"syntax.tag" = "#aaaaaa"
 "syntax.type" = "#aaaaaa"
 "syntax.type_def" = "#cccccc"
 "syntax.type_primitive" = "#aaaaaa"

--- a/extras/vscode/themes/monoglow-lack.json
+++ b/extras/vscode/themes/monoglow-lack.json
@@ -382,7 +382,7 @@
         "support.class.component"
       ],
       "settings": {
-        "foreground": "#555555"
+        "foreground": "#aaaaaa"
       }
     },
     {

--- a/extras/vscode/themes/monoglow-void.json
+++ b/extras/vscode/themes/monoglow-void.json
@@ -382,7 +382,7 @@
         "support.class.component"
       ],
       "settings": {
-        "foreground": "#585858"
+        "foreground": "#b1b1b1"
       }
     },
     {

--- a/extras/vscode/themes/monoglow-z.json
+++ b/extras/vscode/themes/monoglow-z.json
@@ -382,7 +382,7 @@
         "support.class.component"
       ],
       "settings": {
-        "foreground": "#555555"
+        "foreground": "#aaaaaa"
       }
     },
     {

--- a/lua/monoglow/colors/init.lua
+++ b/lua/monoglow/colors/init.lua
@@ -79,7 +79,7 @@ function M.setup(opts)
     special = colors.gray10,
     string = colors.gray7,
     string_escape = colors.lack,
-    tag = colors.gray5,
+    tag = colors.gray7,
     type = colors.gray7,
     type_def = colors.gray8,
     type_primitive = colors.gray7,

--- a/lua/monoglow/groups/treesitter.lua
+++ b/lua/monoglow/groups/treesitter.lua
@@ -88,7 +88,8 @@ function M.get(c)
     ["@string.regexp"] = { fg = c.syntax.string_escape }, -- For regexes.
     ["@string.special"] = { fg = c.syntax.string_escape },
     ["@tag"] = { fg = c.syntax.tag },
-    ["@tag.attribute"] = { fg = c.gray4 },
+    ["@tag.attribute"] = { fg = c.gray6 },
+    ["@tag.builtin"] = "@tag",
     ["@tag.delimiter"] = "@tag",
     ["@type"] = "Type",
     ["@type.builtin"] = { fg = c.syntax.type_primitive },

--- a/tests/minit.lua
+++ b/tests/minit.lua
@@ -3,12 +3,48 @@
 vim.env.LAZY_STDPATH = ".tests"
 load(vim.fn.system("curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua"))()
 
--- Setup lazy
-require("lazy.minit").setup({
-  spec = {
-    {
-      dir = vim.uv.cwd(),
-      opts = {},
-    },
+local spec = {
+  {
+    dir = vim.uv.cwd(),
+    lazy = false,
+    priority = 1000,
+    opts = {},
+    config = function(_, opts)
+      require("monoglow").setup(opts)
+      vim.cmd.colorscheme("monoglow")
+    end,
   },
-})
+}
+
+-- Add treesitter when TS=1 environment variable is set
+if vim.env.TS == "1" then
+  table.insert(spec, {
+    "nvim-treesitter/nvim-treesitter",
+    build = ":TSUpdate",
+    config = function()
+      require("nvim-treesitter.configs").setup({
+        ensure_installed = {
+          "c",
+          "css",
+          "html",
+          "javascript",
+          "lua",
+          "python",
+          "rust",
+          "toml",
+          "tsx",
+          "typescript",
+          "vim",
+          "vimdoc",
+          "xml",
+          "vue",
+          "zig",
+        },
+        highlight = { enable = true },
+      })
+    end,
+  })
+end
+
+-- Setup lazy
+require("lazy.minit").setup({ spec = spec })


### PR DESCRIPTION
- Brighten tag names from gray5 to gray7 (#555555 → #aaaaaa)
- Brighten tag attributes from gray4 to gray6 (#444444 → #7a7a7a)
- Add @tag.builtin highlight to ensure TSX/JSX native elements match
  HTML tag brightness
- Update treesitter.lua function signature to accept opts parameter
- Add treesitter support to test config (TS=1 env var)
- Default test config to monoglow colorscheme
