### PR TITLE
fix(helix): correct generator bugs and expand spec coverage

### DIFF
--- a/extras/helix/monoglow_lack.toml
+++ b/extras/helix/monoglow_lack.toml
@@ -1,6 +1,8 @@
 attribute = { fg = "#727272" }
 comment = { fg = "#474747", modifiers = ["italic"] }
-"comment.block.documentation" = 
+"comment.block.documentation" = { fg = "#474747", modifiers = ["italic"] }
+"comment.line.documentation" = { fg = "#474747", modifiers = ["italic"] }
+"comment.unused" = { fg = "syntax.comment", modifiers = ["italic"] }
 constant = { fg = "#aaaaaa" }
 "constant.builtin" = { fg = "#7a7a7a" }
 "constant.builtin.boolean" = { fg = "#66b2b2" }
@@ -10,14 +12,19 @@ constant = { fg = "#aaaaaa" }
 "constant.numeric.float" = { fg = "#aaaaaa" }
 "constant.numeric.integer" = { fg = "#aaaaaa" }
 constructor = { fg = "#aaaaaa" }
-"diagnostic.error" = { underline = { style = "curl" } }
-"diagnostic.hint" = { underline = { style = "curl" } }
-"diagnostic.info" = { underline = { style = "curl" } }
-"diagnostic.warning" = { underline = { style = "curl" } }
-"diff.delta" = 
-"diff.delta.moved" = 
-"diff.minus" = 
-"diff.plus" = 
+"diagnostic.error" = { fg = "error", underline = { style = "curl" } }
+"diagnostic.hint" = { fg = "hint", underline = { style = "curl" } }
+"diagnostic.info" = { fg = "info", underline = { style = "curl" } }
+"diagnostic.unnecessary" = { fg = "gray5", modifiers = ["italic"] }
+"diagnostic.warning" = { fg = "warning", underline = { style = "curl" } }
+"diff.delta" = { fg = "diff.change" }
+"diff.delta.conflict" = { fg = "diff.text" }
+"diff.delta.gutter" = { fg = "#7a7a7a" }
+"diff.delta.moved" = { fg = "diff.change" }
+"diff.minus" = { fg = "diff.delete" }
+"diff.minus.gutter" = { fg = "#9f7276" }
+"diff.plus" = { fg = "diff.add" }
+"diff.plus.gutter" = { fg = "#769f7f" }
 error = { fg = "#ffc0b9" }
 function = { fg = "#cccccc", modifiers = ["bold"] }
 "function.builtin" = { fg = "#646464" }
@@ -30,56 +37,81 @@ keyword = { fg = "#727272" }
 "keyword.control" = { fg = "#727272", modifiers = ["bold"] }
 "keyword.control.conditional" = { fg = "#727272", modifiers = ["bold"] }
 "keyword.control.exception" = { fg = "#727272", modifiers = ["bold"] }
+"keyword.control.import" = { fg = "#727272", modifiers = ["bold"] }
 "keyword.control.repeat" = { fg = "#727272", modifiers = ["bold"] }
 "keyword.control.return" = { fg = "#6c6c6c", modifiers = ["bold"] }
 "keyword.directive" = { fg = "#727272", modifiers = ["bold"] }
-"keyword.function" = 
+"keyword.function" = { fg = "fg", modifiers = ["bold"] }
 "keyword.operator" = { fg = "#727272", modifiers = ["bold"] }
+"keyword.storage" = { fg = "#727272", modifiers = ["bold"] }
+"keyword.storage.modifier" = { fg = "#727272", modifiers = ["bold"] }
+"keyword.storage.type" = { fg = "#aaaaaa" }
 label = { fg = "#7a7a7a" }
-"markup.bold" = 
-"markup.heading" = { fg = "#7a7a7a" }
-"markup.heading.completion" = { bg = "#191919", fg = "#cccccc" }
-"markup.heading.hover" = { bg = "#1bfd9c", fg = "#0d0d0d", modifiers = ["bold"] }
-"markup.italic" = 
-"markup.link" = { fg = "#7a7a7a" }
-"markup.link.label" = { fg = "#f1f1f1" }
+"markup.bold" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading" = { fg = "fg_sidebar", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg_menu", fg = "fg", modifiers = ["bold"] }
+"markup.heading.hover" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"markup.italic" = { fg = "gray6", modifiers = ["italic"] }
+"markup.link" = { fg = "fg_sidebar", modifiers = ["underline"] }
+"markup.link.label" = { fg = "gray10", modifiers = ["underline"] }
 "markup.link.text" = { fg = "#7a7a7a" }
-"markup.link.url" = { underline = { style = "line" } }
+"markup.link.url" = { fg = "glow", underline = { style = "line" } }
 "markup.list" = { fg = "#444444" }
-"markup.normal.completion" = { fg = "#474747" }
-"markup.normal.hover" = 
+"markup.list.checked" = { fg = "#b3f6c0" }
+"markup.list.unchecked" = { fg = "#8cf8f7" }
+"markup.normal.completion" = { bg = "#191919", fg = "#cccccc" }
+"markup.normal.hover" = { bg = "bg_menu", fg = "syntax.keyword_return" }
+"markup.quote" = { fg = "#7a7a7a" }
 "markup.raw" = { fg = "#aaaaaa" }
-"markup.raw.inline" = 
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.raw.inline" = { fg = "#aaaaaa" }
+"markup.strikethrough" = { fg = "gray7", modifiers = ["crossed_out"] }
 namespace = { fg = "#727272", modifiers = ["bold"] }
 operator = { fg = "#1bfd9c", modifiers = ["bold"] }
+punctuation = { fg = "#cccccc" }
+"punctuation.bracket" = { fg = "#cccccc" }
+"punctuation.delimiter" = { fg = "#cccccc" }
+"punctuation.special" = { fg = "#cccccc" }
 special = { fg = "#f1f1f1" }
 string = { fg = "#aaaaaa" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
 tag = { fg = "#aaaaaa" }
+"tag.builtin" = { fg = "#aaaaaa" }
 type = { fg = "#aaaaaa" }
 "type.builtin" = { fg = "#aaaaaa" }
 "type.enum" = { fg = "#aaaaaa" }
 "type.enum.variant" = { fg = "#aaaaaa" }
+"type.parameter" = { fg = "#cccccc" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline" = { bg = "bg_statusline", fg = "fg_sidebar" }
+"ui.bufferline.active" = { bg = "bg", fg = "fg", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg_statusline" }
 "ui.cursor" = { bg = "#cccccc", fg = "#101010" }
 "ui.cursor.match" = { fg = "#1bfd9c", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#444444" }
-"ui.linenr.select" = { fg = "#aaaaaa" }
+"ui.linenr.selected" = { fg = "#aaaaaa" }
 "ui.menu" = { bg = "#191919", fg = "#cccccc" }
-"ui.menu.scroll" = { bg = 2763306, fg = 5592405 }
+"ui.menu.scroll" = { bg = "#2a2a2a", fg = "#555555" }
 "ui.menu.selected" = { bg = "#1bfd9c", fg = "#0d0d0d", modifiers = ["bold"] }
+"ui.picker.header" = { fg = "#cccccc", modifiers = ["bold"] }
+"ui.picker.header.column.active" = { bg = "#1f1f1f", fg = "#cccccc", modifiers = ["bold"] }
 "ui.popup" = { fg = "#444444" }
-"ui.selection" = { bg = "bg_highlight" }
+"ui.selection" = { bg = "visual" }
 "ui.statusline" = { bg = "#161616", fg = "#7a7a7a" }
 "ui.statusline.inactive" = { bg = "#161616", fg = "#444444" }
-"ui.statusline.normal" = { bg = "blue", fg = "black" }
+"ui.statusline.insert" = { bg = "light_cyan", fg = "black", modifiers = ["bold"] }
+"ui.statusline.normal" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "light_yellow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "border" }
 "ui.text" = { bg = "#101010", fg = "#cccccc" }
+"ui.text.directory" = { fg = "#aaaaaa" }
 "ui.text.focus" = { bg = "#282828" }
 "ui.text.inactive" = { fg = "#474747", modifiers = ["italic"] }
 "ui.text.info" = { fg = "#cccccc" }
+"ui.text.symlink" = { fg = "fs.link" }
 "ui.virtual.inlay-hint" = { bg = "#252626", fg = "#deeeed" }
+"ui.virtual.jump-label" = { fg = "glow", modifiers = ["bold"] }
+"ui.virtual.whitespace" = { fg = "#202020" }
 "ui.window" = { fg = "#444444" }
 variable = { fg = "#cccccc" }
 "variable.builtin" = { fg = "#6f6f6f" }

--- a/extras/helix/monoglow_light.toml
+++ b/extras/helix/monoglow_light.toml
@@ -1,6 +1,8 @@
 attribute = { fg = "#7d7d7d" }
 comment = { fg = "#a0a0a0", modifiers = ["italic"] }
-"comment.block.documentation" = 
+"comment.block.documentation" = { fg = "#a0a0a0", modifiers = ["italic"] }
+"comment.line.documentation" = { fg = "#a0a0a0", modifiers = ["italic"] }
+"comment.unused" = { fg = "syntax.comment", modifiers = ["italic"] }
 constant = { fg = "#555555" }
 "constant.builtin" = { fg = "#707070" }
 "constant.builtin.boolean" = { fg = "#2e8a8a" }
@@ -10,14 +12,19 @@ constant = { fg = "#555555" }
 "constant.numeric.float" = { fg = "#555555" }
 "constant.numeric.integer" = { fg = "#555555" }
 constructor = { fg = "#555555" }
-"diagnostic.error" = { underline = { style = "curl" } }
-"diagnostic.hint" = { underline = { style = "curl" } }
-"diagnostic.info" = { underline = { style = "curl" } }
-"diagnostic.warning" = { underline = { style = "curl" } }
-"diff.delta" = 
-"diff.delta.moved" = 
-"diff.minus" = 
-"diff.plus" = 
+"diagnostic.error" = { fg = "error", underline = { style = "curl" } }
+"diagnostic.hint" = { fg = "hint", underline = { style = "curl" } }
+"diagnostic.info" = { fg = "info", underline = { style = "curl" } }
+"diagnostic.unnecessary" = { fg = "gray5", modifiers = ["italic"] }
+"diagnostic.warning" = { fg = "warning", underline = { style = "curl" } }
+"diff.delta" = { fg = "diff.change" }
+"diff.delta.conflict" = { fg = "diff.text" }
+"diff.delta.gutter" = { fg = "#707070" }
+"diff.delta.moved" = { fg = "diff.change" }
+"diff.minus" = { fg = "diff.delete" }
+"diff.minus.gutter" = { fg = "#bf8383" }
+"diff.plus" = { fg = "diff.add" }
+"diff.plus.gutter" = { fg = "#7ba283" }
 error = { fg = "#c04040" }
 function = { fg = "#3a3a3a", modifiers = ["bold"] }
 "function.builtin" = { fg = "#858585" }
@@ -30,56 +37,81 @@ keyword = { fg = "#7d7d7d" }
 "keyword.control" = { fg = "#7d7d7d", modifiers = ["bold"] }
 "keyword.control.conditional" = { fg = "#7d7d7d", modifiers = ["bold"] }
 "keyword.control.exception" = { fg = "#7d7d7d", modifiers = ["bold"] }
+"keyword.control.import" = { fg = "#7d7d7d", modifiers = ["bold"] }
 "keyword.control.repeat" = { fg = "#7d7d7d", modifiers = ["bold"] }
 "keyword.control.return" = { fg = "#808080", modifiers = ["bold"] }
 "keyword.directive" = { fg = "#7d7d7d", modifiers = ["bold"] }
-"keyword.function" = 
+"keyword.function" = { fg = "fg", modifiers = ["bold"] }
 "keyword.operator" = { fg = "#7d7d7d", modifiers = ["bold"] }
+"keyword.storage" = { fg = "#7d7d7d", modifiers = ["bold"] }
+"keyword.storage.modifier" = { fg = "#7d7d7d", modifiers = ["bold"] }
+"keyword.storage.type" = { fg = "#555555" }
 label = { fg = "#707070" }
-"markup.bold" = 
-"markup.heading" = { fg = "#707070" }
-"markup.heading.completion" = { bg = "#e7e7e7", fg = "#3a3a3a" }
-"markup.heading.hover" = { bg = "#059669", fg = "#f3f3f3", modifiers = ["bold"] }
-"markup.italic" = 
-"markup.link" = { fg = "#707070" }
-"markup.link.label" = { fg = "#151515" }
+"markup.bold" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading" = { fg = "fg_sidebar", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg_menu", fg = "fg", modifiers = ["bold"] }
+"markup.heading.hover" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"markup.italic" = { fg = "gray6", modifiers = ["italic"] }
+"markup.link" = { fg = "fg_sidebar", modifiers = ["underline"] }
+"markup.link.label" = { fg = "gray10", modifiers = ["underline"] }
 "markup.link.text" = { fg = "#707070" }
-"markup.link.url" = { underline = { style = "line" } }
+"markup.link.url" = { fg = "glow", underline = { style = "line" } }
 "markup.list" = { fg = "#b0b0b0" }
-"markup.normal.completion" = { fg = "#a0a0a0" }
-"markup.normal.hover" = 
+"markup.list.checked" = { fg = "#2a7a40" }
+"markup.list.unchecked" = { fg = "#1a8a89" }
+"markup.normal.completion" = { bg = "#e7e7e7", fg = "#3a3a3a" }
+"markup.normal.hover" = { bg = "bg_menu", fg = "syntax.keyword_return" }
+"markup.quote" = { fg = "#707070" }
 "markup.raw" = { fg = "#555555" }
-"markup.raw.inline" = 
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.raw.inline" = { fg = "#555555" }
+"markup.strikethrough" = { fg = "gray7", modifiers = ["crossed_out"] }
 namespace = { fg = "#7d7d7d", modifiers = ["bold"] }
 operator = { fg = "#059669", modifiers = ["bold"] }
+punctuation = { fg = "#3a3a3a" }
+"punctuation.bracket" = { fg = "#3a3a3a" }
+"punctuation.delimiter" = { fg = "#3a3a3a" }
+"punctuation.special" = { fg = "#3a3a3a" }
 special = { fg = "#151515" }
 string = { fg = "#555555" }
 "string.regexp" = { fg = "#506070" }
 "string.special" = { fg = "#506070" }
 tag = { fg = "#555555" }
+"tag.builtin" = { fg = "#555555" }
 type = { fg = "#555555" }
 "type.builtin" = { fg = "#555555" }
 "type.enum" = { fg = "#555555" }
 "type.enum.variant" = { fg = "#555555" }
+"type.parameter" = { fg = "#3a3a3a" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline" = { bg = "bg_statusline", fg = "fg_sidebar" }
+"ui.bufferline.active" = { bg = "bg", fg = "fg", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg_statusline" }
 "ui.cursor" = { bg = "#3a3a3a", fg = "#f0f0f0" }
 "ui.cursor.match" = { fg = "#059669", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#b0b0b0" }
-"ui.linenr.select" = { fg = "#555555" }
+"ui.linenr.selected" = { fg = "#555555" }
 "ui.menu" = { bg = "#e7e7e7", fg = "#3a3a3a" }
-"ui.menu.scroll" = { bg = 13684944, fg = 9474192 }
+"ui.menu.scroll" = { bg = "#d0d0d0", fg = "#909090" }
 "ui.menu.selected" = { bg = "#059669", fg = "#f3f3f3", modifiers = ["bold"] }
+"ui.picker.header" = { fg = "#3a3a3a", modifiers = ["bold"] }
+"ui.picker.header.column.active" = { bg = "#e1e1e1", fg = "#3a3a3a", modifiers = ["bold"] }
 "ui.popup" = { fg = "#b0b0b0" }
-"ui.selection" = { bg = "bg_highlight" }
+"ui.selection" = { bg = "visual" }
 "ui.statusline" = { bg = "#ebebeb", fg = "#707070" }
 "ui.statusline.inactive" = { bg = "#ebebeb", fg = "#b0b0b0" }
-"ui.statusline.normal" = { bg = "blue", fg = "black" }
+"ui.statusline.insert" = { bg = "light_cyan", fg = "black", modifiers = ["bold"] }
+"ui.statusline.normal" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "light_yellow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "border" }
 "ui.text" = { bg = "#f0f0f0", fg = "#3a3a3a" }
+"ui.text.directory" = { fg = "#555555" }
 "ui.text.focus" = { bg = "#d9d9d9" }
 "ui.text.inactive" = { fg = "#a0a0a0", modifiers = ["italic"] }
 "ui.text.info" = { fg = "#3a3a3a" }
+"ui.text.symlink" = { fg = "fs.link" }
 "ui.virtual.inlay-hint" = { bg = "#dce1e1", fg = "#2a5e5e" }
+"ui.virtual.jump-label" = { fg = "glow", modifiers = ["bold"] }
+"ui.virtual.whitespace" = { fg = "#d8d8d8" }
 "ui.window" = { fg = "#b0b0b0" }
 variable = { fg = "#3a3a3a" }
 "variable.builtin" = { fg = "#7d7d7d" }

--- a/extras/helix/monoglow_void.toml
+++ b/extras/helix/monoglow_void.toml
@@ -1,6 +1,8 @@
 attribute = { fg = "#949494" }
 comment = { fg = "#585858", modifiers = ["italic"] }
-"comment.block.documentation" = 
+"comment.block.documentation" = { fg = "#585858", modifiers = ["italic"] }
+"comment.line.documentation" = { fg = "#585858", modifiers = ["italic"] }
+"comment.unused" = { fg = "syntax.comment", modifiers = ["italic"] }
 constant = { fg = "#b1b1b1" }
 "constant.builtin" = { fg = "#a1a1a1" }
 "constant.builtin.boolean" = { fg = "#66b2b2" }
@@ -10,14 +12,19 @@ constant = { fg = "#b1b1b1" }
 "constant.numeric.float" = { fg = "#b1b1b1" }
 "constant.numeric.integer" = { fg = "#b1b1b1" }
 constructor = { fg = "#b1b1b1" }
-"diagnostic.error" = { underline = { style = "curl" } }
-"diagnostic.hint" = { underline = { style = "curl" } }
-"diagnostic.info" = { underline = { style = "curl" } }
-"diagnostic.warning" = { underline = { style = "curl" } }
-"diff.delta" = 
-"diff.delta.moved" = 
-"diff.minus" = 
-"diff.plus" = 
+"diagnostic.error" = { fg = "error", underline = { style = "curl" } }
+"diagnostic.hint" = { fg = "hint", underline = { style = "curl" } }
+"diagnostic.info" = { fg = "info", underline = { style = "curl" } }
+"diagnostic.unnecessary" = { fg = "gray5", modifiers = ["italic"] }
+"diagnostic.warning" = { fg = "warning", underline = { style = "curl" } }
+"diff.delta" = { fg = "diff.change" }
+"diff.delta.conflict" = { fg = "diff.text" }
+"diff.delta.gutter" = { fg = "#a1a1a1" }
+"diff.delta.moved" = { fg = "diff.change" }
+"diff.minus" = { fg = "diff.delete" }
+"diff.minus.gutter" = { fg = "#a4777b" }
+"diff.plus" = { fg = "diff.add" }
+"diff.plus.gutter" = { fg = "#7ba484" }
 error = { fg = "#ffc0b9" }
 function = { fg = "#d1d1d1", modifiers = ["bold"] }
 "function.builtin" = { fg = "#666666" }
@@ -30,56 +37,81 @@ keyword = { fg = "#949494" }
 "keyword.control" = { fg = "#949494", modifiers = ["bold"] }
 "keyword.control.conditional" = { fg = "#949494", modifiers = ["bold"] }
 "keyword.control.exception" = { fg = "#949494", modifiers = ["bold"] }
+"keyword.control.import" = { fg = "#949494", modifiers = ["bold"] }
 "keyword.control.repeat" = { fg = "#949494", modifiers = ["bold"] }
 "keyword.control.return" = { fg = "#6c6c6c", modifiers = ["bold"] }
 "keyword.directive" = { fg = "#949494", modifiers = ["bold"] }
-"keyword.function" = 
+"keyword.function" = { fg = "fg", modifiers = ["bold"] }
 "keyword.operator" = { fg = "#949494", modifiers = ["bold"] }
+"keyword.storage" = { fg = "#949494", modifiers = ["bold"] }
+"keyword.storage.modifier" = { fg = "#949494", modifiers = ["bold"] }
+"keyword.storage.type" = { fg = "#b1b1b1" }
 label = { fg = "#a1a1a1" }
-"markup.bold" = 
-"markup.heading" = { fg = "#a1a1a1" }
-"markup.heading.completion" = { bg = "#242424", fg = "#c0c0c0" }
-"markup.heading.hover" = { bg = "#1bfd9c", fg = "#161616", modifiers = ["bold"] }
-"markup.italic" = 
-"markup.link" = { fg = "#a1a1a1" }
-"markup.link.label" = { fg = "#f1f1f1" }
+"markup.bold" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading" = { fg = "fg_sidebar", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg_menu", fg = "fg", modifiers = ["bold"] }
+"markup.heading.hover" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"markup.italic" = { fg = "gray6", modifiers = ["italic"] }
+"markup.link" = { fg = "fg_sidebar", modifiers = ["underline"] }
+"markup.link.label" = { fg = "gray10", modifiers = ["underline"] }
 "markup.link.text" = { fg = "#a1a1a1" }
-"markup.link.url" = { underline = { style = "line" } }
+"markup.link.url" = { fg = "glow", underline = { style = "line" } }
 "markup.list" = { fg = "#404040" }
-"markup.normal.completion" = { fg = "#585858" }
-"markup.normal.hover" = 
+"markup.list.checked" = { fg = "#b3f6c0" }
+"markup.list.unchecked" = { fg = "#8cf8f7" }
+"markup.normal.completion" = { bg = "#242424", fg = "#c0c0c0" }
+"markup.normal.hover" = { bg = "bg_menu", fg = "syntax.keyword_return" }
+"markup.quote" = { fg = "#a1a1a1" }
 "markup.raw" = { fg = "#b1b1b1" }
-"markup.raw.inline" = 
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.raw.inline" = { fg = "#b1b1b1" }
+"markup.strikethrough" = { fg = "gray7", modifiers = ["crossed_out"] }
 namespace = { fg = "#949494", modifiers = ["bold"] }
 operator = { fg = "#1bfd9c", modifiers = ["bold"] }
+punctuation = { fg = "#d1d1d1" }
+"punctuation.bracket" = { fg = "#d1d1d1" }
+"punctuation.delimiter" = { fg = "#d1d1d1" }
+"punctuation.special" = { fg = "#d1d1d1" }
 special = { fg = "#f1f1f1" }
 string = { fg = "#b1b1b1" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
 tag = { fg = "#b1b1b1" }
+"tag.builtin" = { fg = "#b1b1b1" }
 type = { fg = "#b1b1b1" }
 "type.builtin" = { fg = "#b1b1b1" }
 "type.enum" = { fg = "#b1b1b1" }
 "type.enum.variant" = { fg = "#b1b1b1" }
+"type.parameter" = { fg = "#d1d1d1" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline" = { bg = "bg_statusline", fg = "fg_sidebar" }
+"ui.bufferline.active" = { bg = "bg", fg = "fg", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg_statusline" }
 "ui.cursor" = { bg = "#c0c0c0", fg = "#1c1c1c" }
 "ui.cursor.match" = { fg = "#1bfd9c", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#404040" }
-"ui.linenr.select" = { fg = "#b1b1b1" }
+"ui.linenr.selected" = { fg = "#b1b1b1" }
 "ui.menu" = { bg = "#242424", fg = "#c0c0c0" }
-"ui.menu.scroll" = { bg = 3158064, fg = 5789784 }
+"ui.menu.scroll" = { bg = "#303030", fg = "#585858" }
 "ui.menu.selected" = { bg = "#1bfd9c", fg = "#161616", modifiers = ["bold"] }
+"ui.picker.header" = { fg = "#c0c0c0", modifiers = ["bold"] }
+"ui.picker.header.column.active" = { bg = "#292929", fg = "#c0c0c0", modifiers = ["bold"] }
 "ui.popup" = { fg = "#404040" }
-"ui.selection" = { bg = "bg_highlight" }
+"ui.selection" = { bg = "visual" }
 "ui.statusline" = { bg = "#212121", fg = "#a1a1a1" }
 "ui.statusline.inactive" = { bg = "#212121", fg = "#404040" }
-"ui.statusline.normal" = { bg = "blue", fg = "black" }
+"ui.statusline.insert" = { bg = "light_cyan", fg = "black", modifiers = ["bold"] }
+"ui.statusline.normal" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "light_yellow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "border" }
 "ui.text" = { bg = "#1c1c1c", fg = "#c0c0c0" }
+"ui.text.directory" = { fg = "#b1b1b1" }
 "ui.text.focus" = { bg = "#313131" }
 "ui.text.inactive" = { fg = "#585858", modifiers = ["italic"] }
 "ui.text.info" = { fg = "#c0c0c0" }
+"ui.text.symlink" = { fg = "fs.link" }
 "ui.virtual.inlay-hint" = { bg = "#2f3131", fg = "#deeeed" }
+"ui.virtual.jump-label" = { fg = "glow", modifiers = ["bold"] }
+"ui.virtual.whitespace" = { fg = "#414141" }
 "ui.window" = { fg = "#404040" }
 variable = { fg = "#d1d1d1" }
 "variable.builtin" = { fg = "#949494" }

--- a/extras/helix/monoglow_z.toml
+++ b/extras/helix/monoglow_z.toml
@@ -1,6 +1,8 @@
 attribute = { fg = "#707070" }
 comment = { fg = "#585858", modifiers = ["italic"] }
-"comment.block.documentation" = 
+"comment.block.documentation" = { fg = "#585858", modifiers = ["italic"] }
+"comment.line.documentation" = { fg = "#585858", modifiers = ["italic"] }
+"comment.unused" = { fg = "syntax.comment", modifiers = ["italic"] }
 constant = { fg = "#aaaaaa" }
 "constant.builtin" = { fg = "#7a7a7a" }
 "constant.builtin.boolean" = { fg = "#66b2b2" }
@@ -10,14 +12,19 @@ constant = { fg = "#aaaaaa" }
 "constant.numeric.float" = { fg = "#aaaaaa" }
 "constant.numeric.integer" = { fg = "#aaaaaa" }
 constructor = { fg = "#aaaaaa" }
-"diagnostic.error" = { underline = { style = "curl" } }
-"diagnostic.hint" = { underline = { style = "curl" } }
-"diagnostic.info" = { underline = { style = "curl" } }
-"diagnostic.warning" = { underline = { style = "curl" } }
-"diff.delta" = 
-"diff.delta.moved" = 
-"diff.minus" = 
-"diff.plus" = 
+"diagnostic.error" = { fg = "error", underline = { style = "curl" } }
+"diagnostic.hint" = { fg = "hint", underline = { style = "curl" } }
+"diagnostic.info" = { fg = "info", underline = { style = "curl" } }
+"diagnostic.unnecessary" = { fg = "gray5", modifiers = ["italic"] }
+"diagnostic.warning" = { fg = "warning", underline = { style = "curl" } }
+"diff.delta" = { fg = "diff.change" }
+"diff.delta.conflict" = { fg = "diff.text" }
+"diff.delta.gutter" = { fg = "#7a7a7a" }
+"diff.delta.moved" = { fg = "diff.change" }
+"diff.minus" = { fg = "diff.delete" }
+"diff.minus.gutter" = { fg = "#a07377" }
+"diff.plus" = { fg = "diff.add" }
+"diff.plus.gutter" = { fg = "#77a080" }
 error = { fg = "#ffc0b9" }
 function = { fg = "#cccccc", modifiers = ["bold"] }
 "function.builtin" = { fg = "#646464" }
@@ -30,56 +37,81 @@ keyword = { fg = "#707070" }
 "keyword.control" = { fg = "#707070", modifiers = ["bold"] }
 "keyword.control.conditional" = { fg = "#707070", modifiers = ["bold"] }
 "keyword.control.exception" = { fg = "#707070", modifiers = ["bold"] }
+"keyword.control.import" = { fg = "#707070", modifiers = ["bold"] }
 "keyword.control.repeat" = { fg = "#707070", modifiers = ["bold"] }
 "keyword.control.return" = { fg = "#6c6c6c", modifiers = ["bold"] }
 "keyword.directive" = { fg = "#707070", modifiers = ["bold"] }
-"keyword.function" = 
+"keyword.function" = { fg = "fg", modifiers = ["bold"] }
 "keyword.operator" = { fg = "#707070", modifiers = ["bold"] }
+"keyword.storage" = { fg = "#707070", modifiers = ["bold"] }
+"keyword.storage.modifier" = { fg = "#707070", modifiers = ["bold"] }
+"keyword.storage.type" = { fg = "#aaaaaa" }
 label = { fg = "#7a7a7a" }
-"markup.bold" = 
-"markup.heading" = { fg = "#7a7a7a" }
-"markup.heading.completion" = { bg = "#1b1b1b", fg = "#cccccc" }
-"markup.heading.hover" = { bg = "#1bfd9c", fg = "#0e0e0e", modifiers = ["bold"] }
-"markup.italic" = 
-"markup.link" = { fg = "#7a7a7a" }
-"markup.link.label" = { fg = "#f1f1f1" }
+"markup.bold" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading" = { fg = "fg_sidebar", modifiers = ["bold"] }
+"markup.heading.completion" = { bg = "bg_menu", fg = "fg", modifiers = ["bold"] }
+"markup.heading.hover" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"markup.italic" = { fg = "gray6", modifiers = ["italic"] }
+"markup.link" = { fg = "fg_sidebar", modifiers = ["underline"] }
+"markup.link.label" = { fg = "gray10", modifiers = ["underline"] }
 "markup.link.text" = { fg = "#7a7a7a" }
-"markup.link.url" = { underline = { style = "line" } }
+"markup.link.url" = { fg = "glow", underline = { style = "line" } }
 "markup.list" = { fg = "#444444" }
-"markup.normal.completion" = { fg = "#585858" }
-"markup.normal.hover" = 
+"markup.list.checked" = { fg = "#b3f6c0" }
+"markup.list.unchecked" = { fg = "#8cf8f7" }
+"markup.normal.completion" = { bg = "#1b1b1b", fg = "#cccccc" }
+"markup.normal.hover" = { bg = "bg_menu", fg = "syntax.keyword_return" }
+"markup.quote" = { fg = "#7a7a7a" }
 "markup.raw" = { fg = "#aaaaaa" }
-"markup.raw.inline" = 
-"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.raw.inline" = { fg = "#aaaaaa" }
+"markup.strikethrough" = { fg = "gray7", modifiers = ["crossed_out"] }
 namespace = { fg = "#707070", modifiers = ["bold"] }
 operator = { fg = "#1bfd9c", modifiers = ["bold"] }
+punctuation = { fg = "#cccccc" }
+"punctuation.bracket" = { fg = "#cccccc" }
+"punctuation.delimiter" = { fg = "#cccccc" }
+"punctuation.special" = { fg = "#cccccc" }
 special = { fg = "#f1f1f1" }
 string = { fg = "#aaaaaa" }
 "string.regexp" = { fg = "#708090" }
 "string.special" = { fg = "#708090" }
 tag = { fg = "#aaaaaa" }
+"tag.builtin" = { fg = "#aaaaaa" }
 type = { fg = "#aaaaaa" }
 "type.builtin" = { fg = "#aaaaaa" }
 "type.enum" = { fg = "#aaaaaa" }
 "type.enum.variant" = { fg = "#aaaaaa" }
+"type.parameter" = { fg = "#cccccc" }
 "ui.background" = { bg = "bg" }
+"ui.bufferline" = { bg = "bg_statusline", fg = "fg_sidebar" }
+"ui.bufferline.active" = { bg = "bg", fg = "fg", modifiers = ["bold"] }
+"ui.bufferline.background" = { bg = "bg_statusline" }
 "ui.cursor" = { bg = "#cccccc", fg = "#121212" }
 "ui.cursor.match" = { fg = "#1bfd9c", modifiers = ["bold"] }
 "ui.linenr" = { fg = "#444444" }
-"ui.linenr.select" = { fg = "#aaaaaa" }
+"ui.linenr.selected" = { fg = "#aaaaaa" }
 "ui.menu" = { bg = "#1b1b1b", fg = "#cccccc" }
-"ui.menu.scroll" = { bg = 2763306, fg = 5592405 }
+"ui.menu.scroll" = { bg = "#2a2a2a", fg = "#555555" }
 "ui.menu.selected" = { bg = "#1bfd9c", fg = "#0e0e0e", modifiers = ["bold"] }
+"ui.picker.header" = { fg = "#cccccc", modifiers = ["bold"] }
+"ui.picker.header.column.active" = { bg = "#212121", fg = "#cccccc", modifiers = ["bold"] }
 "ui.popup" = { fg = "#444444" }
-"ui.selection" = { bg = "bg_highlight" }
+"ui.selection" = { bg = "visual" }
 "ui.statusline" = { bg = "#181818", fg = "#7a7a7a" }
 "ui.statusline.inactive" = { bg = "#181818", fg = "#444444" }
-"ui.statusline.normal" = { bg = "blue", fg = "black" }
+"ui.statusline.insert" = { bg = "light_cyan", fg = "black", modifiers = ["bold"] }
+"ui.statusline.normal" = { bg = "glow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.select" = { bg = "light_yellow", fg = "black", modifiers = ["bold"] }
+"ui.statusline.separator" = { fg = "border" }
 "ui.text" = { bg = "#121212", fg = "#cccccc" }
+"ui.text.directory" = { fg = "#aaaaaa" }
 "ui.text.focus" = { bg = "#2a2a2a" }
 "ui.text.inactive" = { fg = "#585858", modifiers = ["italic"] }
 "ui.text.info" = { fg = "#cccccc" }
+"ui.text.symlink" = { fg = "fs.link" }
 "ui.virtual.inlay-hint" = { bg = "#262828", fg = "#deeeed" }
+"ui.virtual.jump-label" = { fg = "glow", modifiers = ["bold"] }
+"ui.virtual.whitespace" = { fg = "#343434" }
 "ui.window" = { fg = "#444444" }
 variable = { fg = "#cccccc" }
 "variable.builtin" = { fg = "#707070" }

--- a/lua/monoglow/extra/helix.lua
+++ b/lua/monoglow/extra/helix.lua
@@ -16,11 +16,19 @@ local M = {}
 function M.generate(colors)
   -- Ref: https://github.com/helix-editor/helix/blob/master/book/src/themes.md
   -- nil is used when no equivalent was found.
+  --
+  -- Helix reserves 17 default palette names (default, black, red, green, yellow,
+  -- blue, magenta, cyan, gray, light-{red,green,yellow,blue,magenta,cyan,gray},
+  -- white). Custom palette entries override them. Our `light_*` keys use
+  -- underscores, so they do NOT shadow Helix's hyphenated defaults; `"helix"`
+  -- overrides below must only reference palette keys that actually exist in
+  -- `lua/monoglow/colors/init.lua` after `M.flatten(colors)`.
   local mapping = M.flatten({
     attribute = "@attribute",
     type = {
       "Type",
       builtin = "@type.builtin",
+      parameter = "@lsp.type.typeParameter",
       enum = {
         "@lsp.type.enum",
         variant = "@lsp.type.enumMember",
@@ -57,12 +65,15 @@ function M.generate(colors)
     },
     comment = {
       "@comment",
-      line = nil,
+      line = {
+        nil,
+        documentation = "@comment.documentation",
+      },
       block = {
         nil,
-        -- not sure about that one
-        documentation = "@string.documentation",
+        documentation = "@comment.documentation",
       },
+      unused = { "helix", fg = "syntax.comment", modifiers = { "italic" } },
     },
     variable = {
       "@variable",
@@ -74,23 +85,29 @@ function M.generate(colors)
       },
     },
     label = "@label",
+    punctuation = {
+      "Delimiter",
+      delimiter = "@punctuation.delimiter",
+      bracket = "@punctuation.bracket",
+      special = "@punctuation.special",
+    },
     keyword = {
       "@keyword",
       control = {
         "Statement",
         conditional = "Conditional",
         ["repeat"] = "Repeat",
-        import = nil,
+        import = "Include",
         ["return"] = "@keyword.return",
         exception = "Exception",
       },
       operator = "Statement",
       directive = "PreProc",
-      ["function"] = "@keyword.function",
+      ["function"] = { "helix", fg = "fg", modifiers = { "bold" } },
       storage = {
-        nil, -- rust: `let`
-        type = nil, -- rust: `struct` & `type`
-        modifier = nil, -- rust: `mut`
+        "StorageClass",
+        type = "Structure",
+        modifier = "StorageClass",
       },
     },
     operator = "Operator",
@@ -104,15 +121,14 @@ function M.generate(colors)
     },
     tag = {
       "@tag",
-      -- ???
-      builtin = nil,
+      builtin = "@tag.builtin",
     },
     namespace = "@lsp.type.namespace",
     special = "Special",
     markup = {
       nil,
       heading = {
-        "@markup.heading",
+        { "helix", fg = "fg_sidebar", modifiers = { "bold" } },
         marker = nil,
         -- post-processed to remove the 'h' as we already use the first element (1) as the root value.
         h1 = nil,
@@ -122,32 +138,29 @@ function M.generate(colors)
         h5 = nil,
         h6 = nil,
         -- UI --
-        completion = "Pmenu",
-        hover = "PmenuSel",
+        completion = { "helix", fg = "fg", bg = "bg_menu", modifiers = { "bold" } },
+        hover = { "helix", fg = "black", bg = "glow", modifiers = { "bold" } },
       },
       list = {
         "@markup.list",
         unnumbered = nil,
         numbered = nil,
-        checked = nil,
-        unchecked = nil,
+        checked = "@markup.list.checked",
+        unchecked = "@markup.list.unchecked",
       },
-      bold = "Bold",
-      italic = "Italic",
-      strikethrough = {
-        "helix",
-        modifiers = { "crossed_out" },
-      },
+      bold = { "helix", fg = "fg", modifiers = { "bold" } },
+      italic = { "helix", fg = "gray6", modifiers = { "italic" } },
+      strikethrough = { "helix", fg = "gray7", modifiers = { "crossed_out" } },
       link = {
-        "@markup.link",
-        url = "@markup.link.url",
-        label = "@markup.link.label",
+        { "helix", fg = "fg_sidebar", modifiers = { "underline" } },
+        url = { "helix", fg = "glow", underline = { style = "line" } },
+        label = { "helix", fg = "gray10", modifiers = { "underline" } },
         text = "@markup.link",
       },
-      quote = nil,
+      quote = "@markup.quote",
       raw = {
         "@markup.raw",
-        inline = "@markup.raw.markdown_inline",
+        inline = "@markup.raw",
         block = nil,
         -- UI --
         completion = nil,
@@ -156,23 +169,36 @@ function M.generate(colors)
       -- UI --
       normal = {
         nil,
-        completion = "CmpItemMenu",
-        hover = "CmpItemKindDefault",
+        completion = "Pmenu",
+        hover = { "helix", fg = "syntax.keyword_return", bg = "bg_menu" },
       },
     },
     diff = {
       nil,
-      plus = "diffAdded",
-      minus = "diffRemoved",
+      plus = {
+        { "helix", fg = "diff.add" },
+        gutter = "Added",
+      },
+      minus = {
+        { "helix", fg = "diff.delete" },
+        gutter = "Removed",
+      },
       delta = {
-        "diffChanged",
-        moved = "diffFile",
+        { "helix", fg = "diff.change" },
+        moved = { "helix", fg = "diff.change" },
+        conflict = { "helix", fg = "diff.text" },
+        gutter = "Changed",
       },
     },
     ui = {
       background = {
         { "helix", bg = "bg" },
         separator = nil,
+      },
+      bufferline = {
+        { "helix", fg = "fg_sidebar", bg = "bg_statusline" },
+        active = { "helix", fg = "fg", bg = "bg", modifiers = { "bold" } },
+        background = { "helix", bg = "bg_statusline" },
       },
       cursor = {
         "Cursor",
@@ -201,20 +227,26 @@ function M.generate(colors)
       },
       linenr = {
         "LineNr",
-        select = "CursorLineNr",
+        selected = "CursorLineNr",
+      },
+      picker = {
+        nil,
+        header = {
+          "TelescopePromptTitle",
+          column = {
+            nil,
+            active = "TelescopeSelection",
+          },
+        },
       },
       statusline = {
         "StatusLine",
         inactive = "StatusLineNc",
-        -- Inspired from lualine
-        normal = {
-          "helix",
-          bg = "blue",
-          fg = "black",
-        },
-        insert = nil,
-        select = nil,
-        separator = nil,
+        -- Mode pills (inspired by lualine).
+        normal = { "helix", fg = "black", bg = "glow", modifiers = { "bold" } },
+        insert = { "helix", fg = "black", bg = "light_cyan", modifiers = { "bold" } },
+        select = { "helix", fg = "black", bg = "light_yellow", modifiers = { "bold" } },
+        separator = { "helix", fg = "border" },
       },
       popup = {
         "TelescopeBorder",
@@ -228,10 +260,12 @@ function M.generate(colors)
         focus = "Visual",
         inactive = "Comment",
         info = "TelescopeNormal",
+        directory = "Directory",
+        symlink = { "helix", fg = "fs.link" },
       },
       virtual = {
         ruler = nil,
-        whitespace = nil,
+        whitespace = "Whitespace",
         ["indent-guide"] = nil,
         ["inlay-hint"] = {
           "DiagnosticVirtualTextHint",
@@ -239,18 +273,19 @@ function M.generate(colors)
           type = nil,
         },
         wrap = nil,
+        ["jump-label"] = { "helix", fg = "glow", modifiers = { "bold" } },
       },
       menu = {
         "Pmenu",
         selected = "PmenuSel",
         scroll = {
           "helix",
-          fg = vim.api.nvim_get_hl(0, { name = "PmenuThumb" }).bg,
-          bg = vim.api.nvim_get_hl(0, { name = "PmenuSbar" }).bg,
+          fg = M.to_rgb(vim.api.nvim_get_hl(0, { name = "PmenuThumb" }).bg),
+          bg = M.to_rgb(vim.api.nvim_get_hl(0, { name = "PmenuSbar" }).bg),
         },
       },
       selection = {
-        { "helix", bg = "bg_highlight" },
+        { "helix", bg = "visual" },
         primary = nil,
       },
       cursorline = {
@@ -268,10 +303,11 @@ function M.generate(colors)
     error = "DiagnosticError",
     diagnostic = {
       nil,
-      hint = "DiagnosticUnderlineHint",
-      info = "DiagnosticUnderlineInfo",
-      warning = "DiagnosticUnderlineWarn",
-      error = "DiagnosticUnderlineError",
+      hint = { "helix", fg = "hint", underline = { style = "curl" } },
+      info = { "helix", fg = "info", underline = { style = "curl" } },
+      warning = { "helix", fg = "warning", underline = { style = "curl" } },
+      error = { "helix", fg = "error", underline = { style = "curl" } },
+      unnecessary = { "helix", fg = "gray5", modifiers = { "italic" } },
     },
   })
 
@@ -301,7 +337,11 @@ function M.generate(colors)
       print("Unknown highlight for " .. hx_scope)
       goto continue
     end
-    table.insert(config, string.format("%s = %s", hx_scope, M.to_helix_config(highlight)))
+    local config_str = M.to_helix_config(highlight)
+    if config_str == nil then
+      goto continue
+    end
+    table.insert(config, string.format("%s = %s", hx_scope, config_str))
 
     ::continue::
   end
@@ -386,7 +426,7 @@ function M.to_helix_config(highlight)
       end
       if mods.undercurl and highlight.sp then
         style.underline = {
-          color = M.to_rgb(mods.sp),
+          color = M.to_rgb(highlight.sp),
           style = "curl",
         }
       end
@@ -394,6 +434,9 @@ function M.to_helix_config(highlight)
   end
   if next(modifiers) ~= nil then
     style.modifiers = M.key_set(modifiers)
+  end
+  if not style.fg and not style.bg and not style.underline and not style.modifiers then
+    return nil
   end
   return M.to_toml(style)
 end
@@ -445,6 +488,9 @@ function M.insert_as_toml(buffer, x)
     end
   elseif type(x) == "string" then
     table.insert(buffer, "\"" .. x .. "\"")
+  elseif type(x) == "number" then
+    -- Colors from nvim_get_hl arrive as 24-bit RGB ints; emit as quoted hex.
+    table.insert(buffer, string.format("\"#%06x\"", x))
   elseif type(x) ~= nil then
     table.insert(buffer, tostring(x))
   end


### PR DESCRIPTION
## Summary

Closes #31 — the reporter posted a hand-corrected `monoglow_z.toml` flagging that our generated output was broken. Diffing against their paste surfaced real bugs in `lua/monoglow/extra/helix.lua`; a follow-up audit against the [official Helix theme docs](https://github.com/helix-editor/helix/blob/master/book/src/themes.md) uncovered additional correctness gaps fixed in the same PR.

### Bugs fixed
- **Invalid TOML** (`key = ` with empty RHS) for scopes whose resolved highlight had no fg/bg/modifiers — `to_helix_config` now returns `nil` and the main loop skips.
- **Decimal-integer color values** in `ui.menu.scroll` — `PmenuThumb`/`PmenuSbar` lookups now pass through `to_rgb`, and `insert_as_toml` hex-coerces numbers defensively.
- **Broken palette refs**: `blue` → `glow`, `bg_highlight` → `visual`. `"blue"` was silently falling back to Helix's reserved ANSI blue instead of our accent.
- **Typo**: `ui.linenr.select` → `ui.linenr.selected` (Helix spec uses past tense here, unlike `ui.statusline.select` / `ui.cursor.select`).

### Coverage added (from Helix spec audit)
`punctuation.*`, `type.parameter`, `comment.line.documentation`, `comment.unused`, `keyword.storage.*`, `keyword.control.import`, `diff.*.gutter`, `diff.delta.conflict`, `tag.builtin`, `markup.quote`, `markup.list.{checked,unchecked}`, `ui.bufferline.*`, `ui.picker.header[.column.active]`, `ui.text.{directory,symlink}`, `ui.virtual.{whitespace,jump-label}`, `diagnostic.unnecessary`.

### Theme enrichment
Added explicit `"helix"` overrides so statusline mode pills, diagnostic fg+curl, and markup modifiers (bold/italic/underline/crossed_out) always emit, rather than depending on the linked Neovim highlight carrying them.

## Test plan
- [x] `./scripts/build` regenerates all 4 variants cleanly
- [x] `python3 tomllib` parses `extras/helix/monoglow_{z,lack,light,void}.toml` without error
- [x] No empty-RHS lines (`grep = *$` → empty)
- [x] No decimal-integer values (`grep = *[0-9]+[,}]` → empty)
- [x] Every palette reference in the theme section resolves against `[palette]` or Helix's 17 reserved defaults (verified with a ref-check script)
- [x] `stylua --check lua/monoglow/extra/helix.lua` clean
- [ ] Manual smoke test in Helix (reviewer): load `monoglow_z`, `monoglow_lack`, `monoglow_void`, `monoglow_light` and confirm syntax + UI render as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)